### PR TITLE
Distinguish conditionals

### DIFF
--- a/act-mode.el
+++ b/act-mode.el
@@ -26,11 +26,13 @@
 
 (defvar act-keywords
   '(
+    "#else"
+    "#fi"
+    "#if"
+    "#then"
     "balance"
     "behaviour"
     "calls"
-    "else"
-    "fi"
     "for all"
     "gas"
     "if"
@@ -41,7 +43,6 @@
     "stack"
     "storage"
     "such that"
-    "then"
     "types"
     "where"
     ))

--- a/act-mode.el
+++ b/act-mode.el
@@ -24,8 +24,7 @@
     "uint256"
 ))
 
-(defvar act-keywords
-  '(
+(defvar act-keywords '(
     "#else"
     "#fi"
     "#if"
@@ -45,7 +44,7 @@
     "such that"
     "types"
     "where"
-    ))
+))
 
 (defvar act-identifier-regexp
   "\\([a-zA-Z0-9]\\|-\\)+")


### PR DESCRIPTION
Between native act and K `if`, for example.

Still doesn't work, as the `#` doesn't match.